### PR TITLE
Öğrenci eposta adreslerini düzenle

### DIFF
--- a/app/services/ubs.rb
+++ b/app/services/ubs.rb
@@ -30,7 +30,7 @@ module Ubs
       first_name: first_name,
       last_name: last_name,
       password: params['student_id'],
-      email: 'o' + params['student_id'] + '@ubs.com.tr',
+      email: params['student_id'] + '@stu.omu.edu.tr',
       user_name: 'o' + params['student_id'],
       is_administrative: false,
       ubs_no: 'o' + params['student_id'],


### PR DESCRIPTION
Öğrencilerin @stu.omu.edu.tr li eposta adresleri bulunduğu için ve şuan sisteme öğrenci kaydolurken @ubs.com.tr şeklinde bir mail adresi ile eklendiği için bu güncellemeyi yaptım. 